### PR TITLE
fix: remove duplicate v8-compile-cache

### DIFF
--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -1,4 +1,3 @@
-import 'v8-compile-cache'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { Module, builtinModules } from 'module'
 import { dirname, join, basename } from 'path'


### PR DESCRIPTION
v8-compile-cache has been imported from https://github.com/nuxt-contrib/jiti/blob/da34753d54e4bc726bb354dcbd77b4f3d7f7e0a0/lib/index.js#L9 , so I guess we can remove the it from jiti.js